### PR TITLE
add parsing for TestRequest request string

### DIFF
--- a/.changes/unreleased/Feature-20231207-104509.yaml
+++ b/.changes/unreleased/Feature-20231207-104509.yaml
@@ -1,0 +1,3 @@
+kind: Feature
+body: add parsing for TestRequest request string
+time: 2023-12-07T10:45:09.666128-06:00

--- a/templates.go
+++ b/templates.go
@@ -15,17 +15,24 @@ type FixtureTemplater struct {
 	coreTemplate *template.Template
 }
 
-func (t *FixtureTemplater) Use(contents string) (string, error) {
+func (t *FixtureTemplater) ParseToBytes(contents string) (*bytes.Buffer, error) {
 	clone, err := t.coreTemplate.Clone()
 	if err != nil {
-		return "", fmt.Errorf("error cloneing core template: %s", err)
+		return nil, fmt.Errorf("error cloning core template: %s", err)
 	}
 	target, err := clone.Parse(contents)
 	if err != nil {
-		return "", fmt.Errorf("error parsing template: %s", err)
+		return nil, fmt.Errorf("error parsing template: %s", err)
 	}
 	data := bytes.NewBuffer([]byte{})
-	err = target.Execute(data, nil)
+	if err = target.Execute(data, nil); err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (t *FixtureTemplater) Use(contents string) (string, error) {
+	data, err := t.ParseToBytes(contents)
 	if err != nil {
 		return "", err
 	}

--- a/test_request.go
+++ b/test_request.go
@@ -2,7 +2,9 @@ package autopilot
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -22,7 +24,7 @@ func (t *TestRequest) ResponseAsString() string {
 func NewTestRequest(request string, variables string, response string) TestRequest {
 	testRequest := TestRequest{
 		Request: GraphqlQuery{
-			Query:     request,
+			Query:     templatedString(request),
 			Variables: templatedJson(variables),
 		},
 		Response: templatedJson(response),
@@ -41,6 +43,14 @@ func templatedJson(values string) map[string]any {
 	}
 
 	return valuesJSON
+}
+
+func templatedString(contents string) string {
+	data, err := Templater.ParseToBytes(contents)
+	if err != nil {
+		panic(fmt.Errorf("error parsing template: %s", err))
+	}
+	return strings.TrimSpace(data.String())
 }
 
 func TestRequestResponse(testRequest TestRequest) ResponseWriter {


### PR DESCRIPTION
Extracted some logic in `templates.go` out into `ParseToBytes()` - behavior unchanged there.
Add template parsing to `TestRequest.Request`.