### PR TITLE
expand Ok() to accept one or multiple errors

### DIFF
--- a/autopilot.go
+++ b/autopilot.go
@@ -162,10 +162,12 @@ func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 }
 
 // Ok fails the test if an err is not nil.
-func Ok(tb testing.TB, err error) {
-	if err != nil {
-		tb.Helper()
-		tb.Fatalf("\n\tunexpected error: %s", err.Error())
+func Ok(tb testing.TB, errors ...error) {
+	for _, err := range errors {
+		if err != nil {
+			tb.Helper()
+			tb.Fatalf("\n\tunexpected error: %s", err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
Elsewhere in `json_test.go` we have this:
```go
	autopilot.Ok(t, data2Err)
	autopilot.Ok(t, err1)
	autopilot.Ok(t, err2)
	autopilot.Ok(t, result3Err)
	autopilot.Ok(t, result4Err)
	autopilot.Ok(t, result4aErr)
	autopilot.Ok(t, result5Err)
	autopilot.Ok(t, result5aErr)
	autopilot.Ok(t, result6Err)
	autopilot.Ok(t, result7Err)
	autopilot.Ok(t, result8Err)
```
but we could have:
```go
	autopilot.Ok(t,
		data2Err,
		err1,
		err2,
		result3Err,
		result4Err,
		result4aErr,
		result5Err,
		result5aErr,
		result6Err,
		result7Err,
		result8Err,
	)

```